### PR TITLE
Fix catch-all routing for frontend

### DIFF
--- a/client_app.py
+++ b/client_app.py
@@ -2,23 +2,30 @@ from os import path
 
 from flask import Blueprint, send_from_directory
 
-client = Blueprint("client", __name__, static_folder=path.join("frontend", "build"))
+client = Blueprint(
+    "client",
+    __name__,
+    static_folder=path.join("frontend", "build"),
+    static_url_path="",
+)
 
 
-@client.route("/", defaults={"file_name": "", "id": ""})
-@client.route("/<string:file_name>", defaults={"id": ""})
-@client.route("/<string:file_name>/<string:id>")
-def serve(file_name, id):
-    if file_name != "" and path.exists(path.join(client.static_folder, file_name)):
-        return send_from_directory(client.static_folder, file_name)
-    else:
-        return send_from_directory(client.static_folder, "index.html")
+@client.route("/", defaults={"requested_path": ""})
+@client.route("/<path:requested_path>")
+def serve(requested_path: str):
+    """Serve the React application."""
+    full_path = path.join(client.static_folder, requested_path)
+
+    if requested_path and path.exists(full_path):
+        return send_from_directory(client.static_folder, requested_path)
+
+    return send_from_directory(client.static_folder, "index.html")
 
 
 @client.route("/static/<path:path_to_file>/<string:file_name>")
-def serve_static(path_to_file, file_name):
-    print(path_to_file, file_name)
-
+def serve_static(path_to_file: str, file_name: str):
+    """Serve static assets from the React build folder."""
     return send_from_directory(
-        path.join(client.static_folder, "static", path_to_file), file_name
+        path.join(client.static_folder, "static", path_to_file),
+        file_name,
     )


### PR DESCRIPTION
## Summary
- refine Flask blueprint to catch arbitrary nested paths
- add static_url_path and docstring for static handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68404efdc38083208354930b7898ee1d