### PR TITLE
Add Celery Twitter posting task

### DIFF
--- a/backend/outbound/queue/tasks/translation_task.py
+++ b/backend/outbound/queue/tasks/translation_task.py
@@ -51,6 +51,9 @@ def create_app() -> Flask:
 app = create_app()
 celery = app.extensions["celery"]
 
+# Import additional task modules so Celery registers them
+from . import twitter_tasks  # noqa: E402,F401
+
 env = os.environ.get("FLASK_ENV", "dev")
 if env == "test":
     translator = Translator(TestLMM())

--- a/backend/outbound/queue/tasks/twitter_tasks.py
+++ b/backend/outbound/queue/tasks/twitter_tasks.py
@@ -1,6 +1,5 @@
 import os
 import requests
-from requests_oauthlib import OAuth1
 
 from celery.schedules import crontab
 
@@ -18,15 +17,11 @@ def fetch_question() -> str:
 
 
 def tweet(text: str) -> None:
-    """Post a tweet using OAuth1 user context."""
-    auth = OAuth1(
-        os.getenv("TWITTER_API_KEY"),
-        os.getenv("TWITTER_API_SECRET_KEY"),
-        os.getenv("TWITTER_ACCESS_TOKEN"),
-        os.getenv("TWITTER_ACCESS_TOKEN_SECRET"),
-    )
+    """Post to X using OAuth 2.0 bearer token."""
+    token = os.getenv("TWITTER_ACCESS_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"}
     resp = requests.post(
-        "https://api.twitter.com/2/tweets", json={"text": text}, auth=auth
+        "https://api.twitter.com/2/tweets", json={"text": text}, headers=headers
     )
     if resp.status_code not in (200, 201):
         raise Exception(f"Tweet failed: {resp.status_code} {resp.text}")

--- a/backend/outbound/queue/tasks/twitter_tasks.py
+++ b/backend/outbound/queue/tasks/twitter_tasks.py
@@ -1,0 +1,50 @@
+import os
+import requests
+from requests_oauthlib import OAuth1
+
+from celery.schedules import crontab
+
+from .translation_task import celery
+
+
+def fetch_question() -> str:
+    """Fetch a random question from the production API within 280 chars."""
+    while True:
+        resp = requests.get("https://jous.app/api/question/random", timeout=10)
+        resp.raise_for_status()
+        content = resp.json().get("question", {}).get("content", "")
+        if content and len(content) <= 240:
+            return f"{content}\nby https://jous.app"
+
+
+def tweet(text: str) -> None:
+    """Post a tweet using OAuth1 user context."""
+    auth = OAuth1(
+        os.getenv("TWITTER_API_KEY"),
+        os.getenv("TWITTER_API_SECRET_KEY"),
+        os.getenv("TWITTER_ACCESS_TOKEN"),
+        os.getenv("TWITTER_ACCESS_TOKEN_SECRET"),
+    )
+    resp = requests.post(
+        "https://api.twitter.com/2/tweets", json={"text": text}, auth=auth
+    )
+    if resp.status_code not in (200, 201):
+        raise Exception(f"Tweet failed: {resp.status_code} {resp.text}")
+
+
+@celery.task(name="backend.outbound.queue.tasks.twitter_tasks.tweet_random_question")
+def tweet_random_question() -> None:
+    """Celery task to fetch a random question and tweet it."""
+    question = fetch_question()
+    tweet(question)
+
+
+# Run three times a day (every 8 hours)
+celery.conf.beat_schedule.setdefault(
+    "tweet-random-question",
+    {
+        "task": "backend.outbound.queue.tasks.twitter_tasks.tweet_random_question",
+        "schedule": crontab(minute=0, hour="*/8"),
+    },
+)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ psycopg2-binary>=2.8
 python-telegram-bot==21.1.1
 google-analytics-data==0.18.17
 requests==2.31.0
-APScheduler==3.10.4
-openai==1.59.5
+APScheduler==3.10.4openai==1.59.5
 celery[redis]==5.4.0
+requests_oauthlib==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ psycopg2-binary>=2.8
 python-telegram-bot==21.1.1
 google-analytics-data==0.18.17
 requests==2.31.0
-APScheduler==3.10.4openai==1.59.5
+openai==1.59.5
 celery[redis]==5.4.0
 requests_oauthlib==1.3.1


### PR DESCRIPTION
## Summary
- add OAuth1 twitter task posting random questions 3 times a day
- load twitter tasks from Celery setup
- include requests_oauthlib in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686e571d3d488320aa9d629d5b8e56b3