### PR TITLE
Reduce frontend dependencies and simplify navbar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "react-dom": "^18.3.1",
         "react-ga4": "^2.1.0",
         "react-helmet": "^6.1.0",
+        "react-icons": "^4.12.0",
         "react-infinite-scroll-component": "^6.1.0",
         "react-pts-canvas": "^0.5.2",
         "react-router-dom": "^5.2.0",
@@ -13942,6 +13943,15 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-infinite-scroll-component": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.3.1",
     "react-ga4": "^2.1.0",
     "react-helmet": "^6.1.0",
+    "react-icons": "^4.12.0",
     "react-infinite-scroll-component": "^6.1.0",
     "react-pts-canvas": "^0.5.2",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/components/App.jsx
+++ b/frontend/src/components/App.jsx
@@ -13,7 +13,6 @@ import Navbar from "./Navbar";
 
 // Styles
 import './customSemantic.less';
-import 'semantic-ui-css/semantic.min.css';
 import "./theme.css";
 import DatabaseBlogData from "./DatabaseBlogData";
 

--- a/frontend/src/components/Auth.css
+++ b/frontend/src/components/Auth.css
@@ -8,3 +8,33 @@
 .auth-segment h2 {
     margin-bottom: 1.5em;
 }
+
+.auth-container {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+form input {
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.5em 1em;
+    background-color: #2185d0;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #1678c2;
+}

--- a/frontend/src/components/Homev2.jsx
+++ b/frontend/src/components/Homev2.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, lazy, Suspense } from 'react';
 import ReactGA from 'react-ga4';
 import { Helmet } from 'react-helmet';
-import { Button } from 'semantic-ui-react';
 import { Cloudinary } from '@cloudinary/url-gen';
 import { fill } from '@cloudinary/url-gen/actions/resize';
 import { AdvancedImage, responsive, placeholder } from '@cloudinary/react';
@@ -10,7 +9,6 @@ import { focusOn } from "@cloudinary/url-gen/qualifiers/gravity";
 import { FocusOn } from "@cloudinary/url-gen/qualifiers/focusOn";
 import { webp } from "@cloudinary/url-gen/qualifiers/format";
 import FloatingPhrases from './FloatingPhrases';
-import 'semantic-ui-css/semantic.min.css';
 import './Homev2Critical.css';
 import './Homev2Full.css';
 
@@ -96,8 +94,7 @@ function Homev2() {
         {cldImage}
         <FloatingPhrases />
         <div className="grid-buttons-position">
-          <Button
-            fluid
+          <button
             style={buttonStyle}
             onClick={() => {
               setShowAbout(true);
@@ -109,7 +106,7 @@ function Homev2() {
             }}
           >
             Start Here
-          </Button>
+          </button>
         </div>
       </div>
       <Suspense fallback={<div style={{ color: 'white' }}>Loading...</div>}>

--- a/frontend/src/components/Homev2Critical.css
+++ b/frontend/src/components/Homev2Critical.css
@@ -37,3 +37,18 @@
   left: 50%;
   transform: translateX(-50%);
 }
+
+.grid-buttons-position button {
+  background-color: rgba(0, 0, 0, 0.35);
+  color: #D6BFA8;
+  padding: 10px 10px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.grid-buttons-position button:hover {
+  background-color: rgba(0, 0, 0, 0.5);
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -3,9 +3,7 @@ import React, { Component } from "react";
 import Alert from "./Alert";
 import { login, check } from "../login";
 import { Helmet } from 'react-helmet';
-import { Form, Button, Segment, Container } from 'semantic-ui-react';
-import 'semantic-ui-css/semantic.min.css';
-import './Auth.css'; // Ensure this file exists with the provided styles
+import './Auth.css';
 import ProductHuntBadge from './ProductHuntBadge';
 
 class Login extends Component {
@@ -26,7 +24,8 @@ class Login extends Component {
         }
     }
 
-    handleChange = (e, { name, value }) => {
+    handleChange = (e) => {
+        const { name, value } = e.target;
         this.setState({ [name]: value });
     };
 
@@ -66,16 +65,14 @@ class Login extends Component {
                     <title>Login</title>
                     <link rel="canonical" href="https://jous.app/login" />
                 </Helmet>
-                <Container textAlign="center">
-                    <Segment padded="very" className="auth-segment">
+                <div className="auth-container">
+                    <div className="auth-segment">
                         <h2>Login</h2>
                         {this.state.err && (
                             <Alert message={`Check your form and try again! (${this.state.err})`} />
                         )}
-                        <Form onSubmit={this.loginUser}>
-                            <Form.Input
-                                fluid
-                                label="Email"
+                        <form onSubmit={this.loginUser}>
+                            <input
                                 placeholder="Email"
                                 type="text"
                                 name="email"
@@ -83,9 +80,7 @@ class Login extends Component {
                                 onChange={this.handleChange}
                                 required
                             />
-                            <Form.Input
-                                fluid
-                                label="Password"
+                            <input
                                 placeholder="Password"
                                 type="password"
                                 name="password"
@@ -93,17 +88,15 @@ class Login extends Component {
                                 onChange={this.handleChange}
                                 required
                             />
-                            <Button type="submit" color="blue" fluid>
-                                Login
-                            </Button>
-                        </Form>
+                            <button type="submit">Login</button>
+                        </form>
                         <div style={{ marginTop: '1em' }}>
                             Don't have an account? <a href="/register">Register here</a>
                         </div>
-                    </Segment>
+                    </div>
                     <br/>
                     <ProductHuntBadge/>
-                </Container>
+                </div>
             </div>
         );
     }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,8 @@
 // src/components/Navbar.js
 import React, { useState, useEffect, Suspense, lazy, useCallback } from "react";
 import ReactGA from 'react-ga4';
-import { Button, Icon } from "semantic-ui-react"; // Import Icon from Semantic UI
+// Icons from a lightweight library
+import { FaLanguage, FaFilter, FaBars, FaBug, FaRandom, FaUser, FaBell } from 'react-icons/fa';
 import { getCurrentUser } from "../login";
 import { useLanguage } from "./LanguageContext";
 import "./NavbarCritical.css"; // Import critical CSS
@@ -128,20 +129,20 @@ function Navbar() {
   // Additional Buttons for Mobile View
   const mobileExtraButtons = (
     <>
-      <Button
+      <button
         className="nav-button"
         onClick={openLanguageModal}
         title="Language"
       >
-        <Icon name="language" />
-      </Button>
-      <Button
+        <FaLanguage />
+      </button>
+      <button
         className="nav-button"
         onClick={() => setOpenFilterModal(true)}
         title="Filter"
       >
-        <Icon name="filter" />
-      </Button>
+        <FaFilter />
+      </button>
     </>
   );
 
@@ -151,43 +152,43 @@ function Navbar() {
         Jous
       </div>
       <div className="menu-items">
-        <Button
+        <button
           className="nav-button"
           onClick={() => route("random")}
           title="Random Questions"
         >
-          <Icon name="random" />
-        </Button>
+          <FaRandom />
+        </button>
 
         {/* Conditionally render additional buttons on mobile */}
         {isCollapsed && (
-          <>
-            <Button
+          <> 
+            <button
               className="nav-button"
               onClick={openLanguageModal}
               title="Language"
             >
-              <Icon name="language" />
-            </Button>
-            <Button
+              <FaLanguage />
+            </button>
+            <button
               className="nav-button"
               onClick={() => setOpenFilterModal(true)}
               title="Filter"
             >
-              <Icon name="filter" />
-            </Button>
+              <FaFilter />
+            </button>
           </>
         )}
 
         {isCollapsed ? (
           <Suspense fallback={null}>
-            <Button
+            <button
               className="nav-button"
               title="Menu"
               onClick={() => setOpenMenu(true)}
             >
-              <Icon name="bars" />
-            </Button>
+              <FaBars />
+            </button>
           </Suspense>
         ) : (
           navbarItems

--- a/frontend/src/components/NavbarItems.jsx
+++ b/frontend/src/components/NavbarItems.jsx
@@ -1,6 +1,6 @@
 // src/components/NavbarItems.js
-import React, { useEffect, useState } from "react";
-import { Button } from "semantic-ui-react";
+import React from "react";
+import { FaBell, FaUser, FaFilter, FaBug } from 'react-icons/fa';
 
 function NavbarItems({
   notify,
@@ -11,63 +11,50 @@ function NavbarItems({
   setOpenFilterModal,
   setOpenActivities,
 }) {
-  const [Icon, setIcon] = useState(null);
-
-  useEffect(() => {
-    if (!Icon) {
-      import("semantic-ui-react/dist/commonjs/elements/Icon/Icon").then((module) =>
-        setIcon(() => module.default)
-      );
-    }
-  }, [Icon]);
-
-  if (!Icon) {
-    return null; // Or a loader/spinner
-  }
 
   return (
     <>
-      <Button
+      <button
         className="nav-button"
         title="notifications"
         onClick={() => setOpenActivities(true)}
       >
-        <i className={`lemon ${notify ? "yellow" : "outline"} icon`} />
-      </Button>
+        <FaBell color={notify ? "#fbbd08" : undefined} />
+      </button>
       {token && (
-        <Button
+        <button
           className="nav-button"
           title="profile"
           onClick={() => route(`user/${user}`)}
         >
-          <i className="user outline icon" />
-        </Button>
+          <FaUser />
+        </button>
       )}
-      <Button
+      <button
         className="nav-button"
         onClick={() => setOpenFilterModal(true)}
         title="Filters"
       >
-        <i className="filter icon" />
-      </Button>
-      <Button className="nav-button" onClick={openLanguageModal}>
+        <FaFilter />
+      </button>
+      <button className="nav-button" onClick={openLanguageModal}>
         Language
-      </Button>
-      <Button className="nav-button" onClick={() => route("blog")}>
+      </button>
+      <button className="nav-button" onClick={() => route("blog")}>
         Blog
-      </Button>
+      </button>
       {!token ? (
-        <Button className="nav-button" onClick={() => route("login")}>
+        <button className="nav-button" onClick={() => route("login")}>
           Login
-        </Button>
+        </button>
       ) : (
-        <Button className="nav-button" onClick={() => route("logout")}>
+        <button className="nav-button" onClick={() => route("logout")}>
           Logout
-        </Button>
+        </button>
       )}
-      <Button className="nav-button" onClick={() => route("bug")}>
-        <i className="bug icon" />
-      </Button>
+      <button className="nav-button" onClick={() => route("bug")}>
+        <FaBug />
+      </button>
     </>
   );
 }

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -4,9 +4,7 @@ import axios from "axios";
 import Alert from "./Alert";
 import { check } from "../login";
 import { Helmet } from 'react-helmet';
-import { Form, Button, Segment, Container } from 'semantic-ui-react';
-import 'semantic-ui-css/semantic.min.css';
-import './Auth.css'; // Ensure this file exists with the provided styles
+import './Auth.css';
 
 class Register extends Component {
     state = {
@@ -24,7 +22,8 @@ class Register extends Component {
         });
     }
 
-    handleChange = (e, { name, value }) => {
+    handleChange = (e) => {
+        const { name, value } = e.target;
         this.setState({ [name]: value });
     };
 
@@ -69,25 +68,21 @@ class Register extends Component {
                     <title>Register</title>
                     <link rel="canonical" href="https://jous.app/register" />
                 </Helmet>
-                <Container textAlign="center">
-                    <Segment padded="very" className="auth-segment">
+                <div className="auth-container">
+                    <div className="auth-segment">
                         <h2>Register</h2>
                         {this.state.err && (
                             <Alert message={`Check your form and try again! (${this.state.err})`} />
                         )}
-                        <Form onSubmit={this.register}>
-                            <Form.Input
-                                fluid
-                                label="Email (optional for resetting password)"
-                                placeholder="Email"
+                        <form onSubmit={this.register}>
+                            <input
+                                placeholder="Email (optional for resetting password)"
                                 type="email"
                                 name="email"
                                 value={this.state.email}
                                 onChange={this.handleChange}
                             />
-                            <Form.Input
-                                fluid
-                                label="Username"
+                            <input
                                 placeholder="Username"
                                 type="text"
                                 name="username"
@@ -95,9 +90,7 @@ class Register extends Component {
                                 onChange={this.handleChange}
                                 required
                             />
-                            <Form.Input
-                                fluid
-                                label="Password"
+                            <input
                                 placeholder="Password"
                                 type="password"
                                 name="password"
@@ -105,15 +98,13 @@ class Register extends Component {
                                 onChange={this.handleChange}
                                 required
                             />
-                            <Button type="submit" color="blue" fluid>
-                                Register
-                            </Button>
-                        </Form>
+                            <button type="submit">Register</button>
+                        </form>
                         <div style={{ marginTop: '1em' }}>
                             Already have an account? <a href="/login">Login here</a>
                         </div>
-                    </Segment>
-                </Container>
+                    </div>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
## Summary
- remove global semantic-ui css import
- swap semantic Button/Icon with lightweight react-icons
- rewrite navbar, auth forms and home button with basic HTML elements
- add styles for new components
- add `react-icons` dependency

## Testing
- `npm install`
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686e55d231e4832083e2dc68c526f64b